### PR TITLE
xcom support

### DIFF
--- a/src/message_checks/bad_words.rs
+++ b/src/message_checks/bad_words.rs
@@ -2,7 +2,7 @@ use lazy_static::lazy_static;
 use regex::Regex;
 use tokio::task;
 
-const BAD_WORDS: &str = r#"\W*((?i)(uwu|:v|owo)(?-i))\W*"#;
+const BAD_WORDS: &str = r"\W*((?i)(uwu|:v|owo)(?-i))\W*";
 
 lazy_static! {
     static ref BAD_WORD_REGEX: Regex = Regex::new(BAD_WORDS).unwrap();

--- a/src/message_checks/twitter.rs
+++ b/src/message_checks/twitter.rs
@@ -1,9 +1,13 @@
 /// Checks if the message contains a twitter link and if it does, it replaces it with a link to the same tweet but in fx.
 pub async fn update_vxtwitter(message: &str) -> Option<String> {
+    println!("{}", message);
     if (message.contains("twitter") && message.contains("status"))
         && !(message.contains("fxtwitter") || message.contains("vxtwitter"))
     {
         let url = message.replace("twitter", "fxtwitter");
+        return Some(url);
+    } else if message.contains("x.com") && message.contains("status") {
+        let url = message.replace("x.com", "fixupx.com");
         return Some(url);
     }
 
@@ -19,5 +23,11 @@ mod tests {
         let twitter = "https://twitter.com/AsukaLangleyS/status/1375160000000000000";
         let fxtwitter = "https://fxtwitter.com/AsukaLangleyS/status/1375160000000000000";
         assert_eq!(update_vxtwitter(twitter).await, Some(fxtwitter.to_string()));
+    }
+    #[tokio::test]
+    async fn test_update_xcom() {
+        let xcom = "https://x.com/AsukaLangleyS/status/1375160000000000000";
+        let fixupx = "https://fixupx.com/AsukaLangleyS/status/1375160000000000000";
+        assert_eq!(update_vxtwitter(xcom).await, Some(fixupx.to_string()));
     }
 }


### PR DESCRIPTION
If you press share in a tweet (or xeet) from the x/twitter phone app it now creates a x.com link instead of twitter.com, i added support to switch from xcom to fixup so that the xeet/tweet does embed